### PR TITLE
Make CommandRegistry#getCommandMap Spigot compatible

### DIFF
--- a/src/main/java/com/thevoxelbox/voxelsniper/command/CommandRegistry.java
+++ b/src/main/java/com/thevoxelbox/voxelsniper/command/CommandRegistry.java
@@ -29,7 +29,7 @@ public class CommandRegistry {
 	@SuppressWarnings("JavaReflectionMemberAccess")
 	private CommandMap getCommandMap(Server server) {
 		try {
-			Method method = Server.class.getDeclaredMethod("getCommandMap");
+			Method method = server.getClass().getDeclaredMethod("getCommandMap");
 			return (CommandMap) method.invoke(server);
 		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
 			throw new RuntimeException(exception);


### PR DESCRIPTION
With this change, the CraftServer class is selected dynamically via getClass().

The Spigot API does not have a Server#getCommandMap (unlike Paper)

Calling getClass().getDeclaredMethod() on the Server object will actually find
the CraftServer method by that name. This call will work on both Spigot and
Paper.